### PR TITLE
Add IAM permissions required for logging components

### DIFF
--- a/cfn/application-account.yaml
+++ b/cfn/application-account.yaml
@@ -72,7 +72,7 @@ Resources:
           - sts:AssumeRole
       ManagedPolicyArns:
         - !Ref IAMManagedPolicyKopsManagementNodeAutoScalingELB
-        - !Ref IAMManagedPolicyKopsManagementNodeCWCWLogsSSN
+        - !Ref IAMManagedPolicyKopsManagementNodeLMA
         - !Ref IAMManagedPolicyKopsManagementNodeDynamoDB
         - !Ref IAMManagedPolicyKopsManagementNodeEC2
         - !Ref IAMManagedPolicyKopsManagementNodeECR
@@ -98,7 +98,7 @@ Resources:
           - sts:AssumeRole
       ManagedPolicyArns:
         - !Sub 'arn:aws:iam::${AWS::AccountId}:policy/customer/KOPS_MANAGEMENT_NODE_autoscaling_elb'
-        - !Sub 'arn:aws:iam::${AWS::AccountId}:policy/customer/KOPS_MANAGEMENT_NODE_cw_cwlogs_sns'
+        - !Sub 'arn:aws:iam::${AWS::AccountId}:policy/customer/KOPS_MANAGEMENT_NODE_lma'
         - !Sub 'arn:aws:iam::${AWS::AccountId}:policy/customer/KOPS_MANAGEMENT_NODE_dynamodb'
         - !Sub 'arn:aws:iam::${AWS::AccountId}:policy/customer/KOPS_MANAGEMENT_NODE_ec2'
         - !Sub 'arn:aws:iam::${AWS::AccountId}:policy/customer/KOPS_MANAGEMENT_NODE_ecr'
@@ -160,11 +160,11 @@ Resources:
               - elasticloadbalancing:*
             Resource: "*"
 
-  IAMManagedPolicyKopsManagementNodeCWCWLogsSSN:
+  IAMManagedPolicyKopsManagementNodeLMA:
     Condition: IsAutoIAMMode
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      ManagedPolicyName: "KOPS_MANAGEMENT_NODE_cw_cwlogs_sns"
+      ManagedPolicyName: "KOPS_MANAGEMENT_NODE_lma"
       Path: !Ref IAMNewManagedPoliciesPath
       PolicyDocument:
         Version: "2012-10-17"

--- a/cfn/operations-account.yaml
+++ b/cfn/operations-account.yaml
@@ -178,7 +178,7 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - !Ref IAMManagedPolicyKopsManagementNodeAutoScalingELB
-        - !Ref IAMManagedPolicyKopsManagementNodeCWCWLogsSSN
+        - !Ref IAMManagedPolicyKopsManagementNodeLMA
         - !Ref IAMManagedPolicyKopsManagementNodeDynamoDB
         - !Ref IAMManagedPolicyKopsManagementNodeEC2
         - !Ref IAMManagedPolicyKopsManagementNodeECR
@@ -203,7 +203,7 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${IAMExistingManagedPoliciesPath}KOPS_MANAGEMENT_NODE_autoscaling_elb"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${IAMExistingManagedPoliciesPath}KOPS_MANAGEMENT_NODE_cw_cwlogs_sns"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${IAMExistingManagedPoliciesPath}KOPS_MANAGEMENT_NODE_lma"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${IAMExistingManagedPoliciesPath}KOPS_MANAGEMENT_NODE_dynamodb"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${IAMExistingManagedPoliciesPath}KOPS_MANAGEMENT_NODE_ec2"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${IAMExistingManagedPoliciesPath}KOPS_MANAGEMENT_NODE_ecr"
@@ -393,11 +393,11 @@ Resources:
               - elasticloadbalancing:*
             Resource: "*"
 
-  IAMManagedPolicyKopsManagementNodeCWCWLogsSSN:
+  IAMManagedPolicyKopsManagementNodeLMA:
     Condition: IsAutoIAMMode
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      ManagedPolicyName: "KOPS_MANAGEMENT_NODE_cw_cwlogs_sns"
+      ManagedPolicyName: "KOPS_MANAGEMENT_NODE_lma"
       Path: !Ref IAMNewManagedPoliciesPath
       PolicyDocument:
         Version: "2012-10-17"
@@ -471,6 +471,26 @@ Resources:
               - sns:ListPlatformApplications
               - sns:GetSMSAttributes
             Resource: "*"
+          -
+            Sid: ES
+            Effect: Allow
+            Action:
+              - es:CreateElasticsearchDomain
+              - es:DescribeElasticsearchDomain
+              - es:AddTags
+              - es:ListTags
+            Resource: "*"
+          -
+            Sid: KINESIS
+            Effect: Allow
+            Action: kinesis:*
+            Resource: "*"
+          -
+            Sid: LAMBDA
+            Effect: Allow
+            Action: lambda:*
+            Resource: "*"
+
 
   IAMManagedPolicyKopsManagementNodeDynamoDB:
     Condition: IsAutoIAMMode

--- a/iam/kops/KOPS_MANAGEMENT_NODE_lma.json
+++ b/iam/kops/KOPS_MANAGEMENT_NODE_lma.json
@@ -93,6 +93,29 @@
             "NotResource":[
                 "arn:aws:sns:*:*:ccc-*"
             ]  
+        },
+        {
+            "Sid": "ES",
+            "Effect": "Allow",
+            "Action": [
+                "es:CreateElasticsearchDomain",
+                "es:DescribeElasticsearchDomain",
+                "es:AddTags",
+                "es:ListTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "KINESIS",
+            "Effect": "Allow",
+            "Action": "kinesis:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "LAMBDA",
+            "Effect": "Allow",
+            "Action": "lambda:*",
+            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
Extend permissions for core-infra Jenkins with ElasticSearch, Lambda and Kinesis.
Put new permissions into renamed "cw_cwlogs_sns" policy to avoid hitting
the limit of number of IAM policy attachements to a role.
Also, in "legacy" mode (policies generated as jsons not created), cross-account
role on application account will receive identical permissions that are not
necessairly needed (this was done to keep things simple).