### PR TITLE
Fix/destroy lma

### DIFF
--- a/cfn/operations-account.yaml
+++ b/cfn/operations-account.yaml
@@ -477,6 +477,8 @@ Resources:
             Action:
               - es:CreateElasticsearchDomain
               - es:DescribeElasticsearchDomain
+              - es:DeleteElasticsearchDomain
+              - es:RemoveTags
               - es:AddTags
               - es:ListTags
             Resource: "*"

--- a/iam/kops/KOPS_MANAGEMENT_NODE_lma.json
+++ b/iam/kops/KOPS_MANAGEMENT_NODE_lma.json
@@ -100,6 +100,8 @@
             "Action": [
                 "es:CreateElasticsearchDomain",
                 "es:DescribeElasticsearchDomain",
+                "es:DeleteElasticsearchDomain",
+                "es:RemoveTags",
                 "es:AddTags",
                 "es:ListTags"
             ],


### PR DESCRIPTION
Added IAM permissions to allow for destroying LMA components in Cloudformation template and JSON template