### PR TITLE
iam:CreateServiceLinkedRole addition to Cloudformation and json templates

### DIFF
--- a/cfn/application-account.yaml
+++ b/cfn/application-account.yaml
@@ -464,6 +464,7 @@ Resources:
               - iam:CreatePolicyVersion
               - iam:DeletePolicyVersion
               - iam:ListPolicyVersions
+              - iam:CreateServiceLinkedRole
             Resource: "*"
 
   IAMManagedPolicyKopsManagementNodeS3:

--- a/cfn/operations-account.yaml
+++ b/cfn/operations-account.yaml
@@ -719,6 +719,7 @@ Resources:
               - iam:CreatePolicyVersion
               - iam:DeletePolicyVersion
               - iam:ListPolicyVersions
+              - iam:CreateServiceLinkedRole
             Resource: "*"
 
   IAMManagedPolicyKopsManagementNodeS3:

--- a/iam/kops/KOPS_MANAGEMENT_NODE_iam.json
+++ b/iam/kops/KOPS_MANAGEMENT_NODE_iam.json
@@ -29,7 +29,8 @@
                 "iam:AddRoleToInstanceProfile",
                 "iam:ListInstanceProfilesForRole",
                 "iam:RemoveRoleFromInstanceProfile",
-                "iam:ListPolicyVersions"
+                "iam:ListPolicyVersions",
+                "iam:CreateServiceLinkedRole"
             ],
             "NotResource":[
             "arn:aws:iam::*:role/ccc-administration/*",


### PR DESCRIPTION
*added iam:CreateServiceLinkedRole permission to json and cfn files. This permission was required when deploying a fresh install of the operations kubernetes cluster