### PR TITLE
IAM permissions for Route53 requests

### DIFF
--- a/cfn/application-account.yaml
+++ b/cfn/application-account.yaml
@@ -419,6 +419,7 @@ Resources:
             Action:
               - route53:GetHostedZone
               - route53:ListHostedZones
+              - route53:ListResourceRecordSets
             Resource: "*"
 
 

--- a/cfn/operations-account.yaml
+++ b/cfn/operations-account.yaml
@@ -674,6 +674,7 @@ Resources:
               - route53:GetHostedZone
               - route53:ChangeResourceRecordSets
               - route53:ListHostedZones
+              - route53:ListResourceRecordSets
             Resource: "*"
 
 

--- a/iam/kops/KOPS_MANAGEMENT_NODE_ecr_route53.json
+++ b/iam/kops/KOPS_MANAGEMENT_NODE_ecr_route53.json
@@ -33,7 +33,8 @@
                 "route53:GetChange",
                 "route53:GetHostedZone",
                 "route53:ChangeResourceRecordSets",
-                "route53:ListHostedZones"
+                "route53:ListHostedZones",
+                "route53:ListResourceRecordSets"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
Added route53:ListResourceRecordSets permission to json and cloudformation templates required for Jenkins Core DNS