### PR TITLE
Update cfn bootstrap patch 1

### DIFF
--- a/cfn/application-account.yaml
+++ b/cfn/application-account.yaml
@@ -486,6 +486,7 @@ Resources:
               - iam:CreatePolicyVersion
               - iam:DeletePolicyVersion
               - iam:ListPolicyVersions
+              - iam:CreateServiceLinkedRole
             Resource: "*"
 
   IAMManagedPolicyKentrikosS3:

--- a/cfn/operations-account.yaml
+++ b/cfn/operations-account.yaml
@@ -728,6 +728,7 @@ Resources:
               - iam:CreatePolicyVersion
               - iam:DeletePolicyVersion
               - iam:ListPolicyVersions
+              - iam:CreateServiceLinkedRole
             Resource: "*"
 
   IAMManagedPolicyKentrikosS3:


### PR DESCRIPTION
Under most circumstances, you don't need to manually create a service-linked role. Amazon EC2 Auto Scaling creates the AWSServiceRoleForAutoScaling service-linked role for you the first time that you create an Auto Scaling group but do not specify a different service-linked role.

For a new account where auto scaling has not been used, the AWSServiceRoleForAutoScaling does not exist and needs to be created by the Cross Account role.

https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-service-linked-role.html